### PR TITLE
Issue #59 - Feature request: Option to switch back to previous Keyboard upon record-completion

### DIFF
--- a/android/app/src/main/java/com/example/whispertoinput/MainActivity.kt
+++ b/android/app/src/main/java/com/example/whispertoinput/MainActivity.kt
@@ -60,6 +60,7 @@ val LANGUAGE_CODE = stringPreferencesKey("language-code")
 val API_KEY = stringPreferencesKey("api-key")
 val MODEL = stringPreferencesKey("model")
 val AUTO_RECORDING_START = booleanPreferencesKey("is-auto-recording-start")
+val AUTO_SWITCH_BACK = booleanPreferencesKey("auto-switch-back")
 val ADD_TRAILING_SPACE = booleanPreferencesKey("add-trailing-space")
 val POSTPROCESSING = stringPreferencesKey("postprocessing")
 
@@ -327,6 +328,10 @@ class MainActivity : AppCompatActivity() {
                 SettingText(R.id.field_api_key, API_KEY),
                 SettingText(R.id.field_model, MODEL, getString(R.string.settings_option_openai_api_default_model)),
                 SettingDropdown(R.id.spinner_auto_recording_start, AUTO_RECORDING_START, hashMapOf(
+                    getString(R.string.settings_option_yes) to true,
+                    getString(R.string.settings_option_no) to false,
+                )),
+                SettingDropdown(R.id.spinner_auto_switch_back, AUTO_SWITCH_BACK, hashMapOf(
                     getString(R.string.settings_option_yes) to true,
                     getString(R.string.settings_option_no) to false,
                 )),

--- a/android/app/src/main/java/com/example/whispertoinput/MainActivity.kt
+++ b/android/app/src/main/java/com/example/whispertoinput/MainActivity.kt
@@ -334,7 +334,7 @@ class MainActivity : AppCompatActivity() {
                 SettingDropdown(R.id.spinner_auto_switch_back, AUTO_SWITCH_BACK, hashMapOf(
                     getString(R.string.settings_option_yes) to true,
                     getString(R.string.settings_option_no) to false,
-                )),
+                ), false),
                 SettingDropdown(R.id.spinner_add_trailing_space, ADD_TRAILING_SPACE, hashMapOf(
                     getString(R.string.settings_option_yes) to true,
                     getString(R.string.settings_option_no) to false,

--- a/android/app/src/main/java/com/example/whispertoinput/WhisperInputService.kt
+++ b/android/app/src/main/java/com/example/whispertoinput/WhisperInputService.kt
@@ -59,6 +59,15 @@ class WhisperInputService : InputMethodService() {
     private fun transcriptionCallback(text: String?) {
         if (!text.isNullOrEmpty()) {
             currentInputConnection?.commitText(text, 1)
+            // Check if auto-switch-back is enabled and switch if so
+            CoroutineScope(Dispatchers.Main).launch {
+                val autoSwitchBack = dataStore.data.map { preferences: Preferences ->
+                    preferences[AUTO_SWITCH_BACK] ?: false
+                }.first()
+                if (autoSwitchBack) {
+                    onSwitchIme()
+                }
+            }
         }
         whisperKeyboard.reset()
     }

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -155,6 +155,7 @@
                 style="@style/SettingsField"
                 android:hint="@string/settings_language_code_hint" />
 
+
             <!-- Auto Recording Start -->
             <TextView
                 android:id="@+id/label_auto_recording_start"
@@ -168,6 +169,20 @@
                 android:id="@+id/spinner_auto_recording_start"
                 style="@style/SettingsSpinner"
                 android:entries="@array/settings_auto_recording_start_array" />
+
+            <!-- Auto Switch Back -->
+            <TextView
+                android:id="@+id/label_auto_switch_back"
+                style="@style/SettingsLabel"
+                android:text="@string/settings_auto_switch_back" />
+            <TextView
+                android:id="@+id/description_auto_switch_back"
+                style="@style/SettingsDescription"
+                android:text="@string/settings_auto_switch_back_desc" />
+            <Spinner
+                android:id="@+id/spinner_auto_switch_back"
+                style="@style/SettingsSpinner"
+                android:entries="@array/settings_auto_switch_back_array" />
 
             <!-- Postprocessing -->
             <TextView

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -155,7 +155,6 @@
                 style="@style/SettingsField"
                 android:hint="@string/settings_language_code_hint" />
 
-
             <!-- Auto Recording Start -->
             <TextView
                 android:id="@+id/label_auto_recording_start"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -65,6 +65,12 @@
         <item>@string/settings_option_yes</item>
         <item>@string/settings_option_no</item>
     </string-array>
+    <string name="settings_auto_switch_back">Auto Switch Back</string>
+    <string name="settings_auto_switch_back_desc">Automatically switch back to the previous keyboard after transcription.</string>
+    <string-array name="settings_auto_switch_back_array">
+        <item>@string/settings_option_yes</item>
+        <item>@string/settings_option_no</item>
+    </string-array>
     <string name="settings_add_trailing_space">Add Trailing Space</string>
     <string name="settings_add_trailing_space_desc">Whether to add a trailing space after the transcribed text.</string>
     <string-array name="settings_add_trailing_space_array">


### PR DESCRIPTION
Implemented change for Issue #59 
https://github.com/j3soon/whisper-to-input/issues/59

Feature idea: “Auto-switch back to previous keyboard after transcription”

**What happens today**: After I dictate a paragraph and the transcription appears, the WhisperInput keyboard stays active.

**The pain point**: I usually review and edit the text right away, so I manually switch back to my regular keyboard (Gboard). Doing this every time slows things down.

**Proposed behavior**: Add an optional setting— e.g., “Auto-switch to previous keyboard when transcription ends.” -> When enabled, the keyboard would automatically return to whichever keyboard was active before recording (Gboard in my case) as soon as the transcription is complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Auto Switch Back" setting to return to the previous keyboard after sending transcribed text. Defaults to No and can be toggled in Settings.

* **UI**
  * Settings updated to include an "Auto Switch Back" section (label, description, Yes/No selector) placed after "Auto Recording Start".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->