### PR TITLE
feat: Add Voxtral (Mistral) and ElevenLabs Scribe STT backends

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,36 @@
+name: Build APK
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x android/gradlew
+
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug
+        working-directory: android
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: whisper-to-input-debug
+          path: android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ The STT/ASR backend service can be either [OpenAI API](https://platform.openai.c
      Model:
      Language Code:           multi
      ```
+   - Voxtral (Mistral):
+     ```
+     Speech to Text Backend:  Voxtral (Mistral)
+     Endpoint:                https://api.mistral.ai/v1/audio/transcriptions
+     API Key:                 <your Mistral API key>
+     Model:                   voxtral-mini-latest
+     Language Code:           auto
+     ```
+   - ElevenLabs Scribe:
+     ```
+     Speech to Text Backend:  ElevenLabs Scribe
+     Endpoint:                https://api.elevenlabs.io/v1/speech-to-text
+     API Key:                 <your ElevenLabs API key>
+     Model:                   scribe_v1
+     Language Code:           auto
+     ```
 
 6. Go to the system settings page and enable the app keyboard. This process may vary depending on your Android version and phone model. The following screenshots are taken on Android 13 of a Asus Zenfone 8.
 
@@ -221,6 +237,33 @@ will show:
 Available ASR models
 {'en,zh,de,es,ru,ko,fr,ja,pt,tr,pl,ca,nl,ar,sv,it,id,hi,fi,vi,he,uk,el,ms,cs,ro,da,hu,ta,no,th,ur,hr,bg,lt,la,mi,ml,cy,sk,te,fa,lv,bn,sr,az,sl,kn,et,mk,br,eu,is,hy,ne,mn,bs,kk,sq,sw,gl,mr,pa,si,km,sn,yo,so,af,oc,ka,be,tg,sd,gu,am,yi,lo,uz,fo,ht,ps,tk,nn,mt,sa,lb,my,bo,tl,mg,as,tt,haw,ln,ha,ba,jw,su,yue,multi': [{'model': ['whisper-large-v3-multi-asr-offline-asr-bls-ensemble']}]}
 ```
+
+### Voxtral (Mistral AI)
+
+Cloud-based speech-to-text API from Mistral AI.
+
+Requires a [Mistral API key](https://console.mistral.ai/api-keys).
+
+- Endpoint: `https://api.mistral.ai/v1/audio/transcriptions`
+- Model: `voxtral-mini-latest` (or `voxtral-small-latest`, `voxtral-mini-2507`)
+- Auth: `Authorization: Bearer <API_KEY>`
+- Language: ISO 639-1 code (e.g., `en`, `zh`, `fr`) or `auto` for auto-detection
+
+See the [Mistral API documentation](https://docs.mistral.ai/api/#tag/audio/operation/createTranscription) for more info.
+
+### ElevenLabs Scribe
+
+Cloud-based speech-to-text API from ElevenLabs.
+
+Requires an [ElevenLabs API key](https://elevenlabs.io/api).
+
+- Endpoint: `https://api.elevenlabs.io/v1/speech-to-text`
+- Model: `scribe_v1`
+- Auth: `xi-api-key: <API_KEY>`
+- Language: ISO 639-1/3 code (e.g., `en`, `eng`, `zh`, `cmn`) or `auto` for auto-detection
+- Optional parameters: `tag_audio_events` (boolean), `timestamps_granularity` (string)
+
+See the [ElevenLabs API documentation](https://elevenlabs.io/docs/api-reference/speech-to-text) for more info.
 
 ## Debugging
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,7 +23,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:allowBackup="true"

--- a/android/app/src/main/java/com/example/whispertoinput/MainActivity.kt
+++ b/android/app/src/main/java/com/example/whispertoinput/MainActivity.kt
@@ -285,6 +285,32 @@ class MainActivity : AppCompatActivity() {
                                 modelEditText.setText(getString(R.string.settings_option_nvidia_nim_default_model))
                                 val languageCodeEditText: EditText = findViewById<EditText>(R.id.field_language_code)
                                 languageCodeEditText.setText(getString(R.string.settings_option_nvidia_nim_default_language))
+                            } else if (selectedItem == getString(R.string.settings_option_voxtral)) {
+                                val endpointEditText: EditText = findViewById<EditText>(R.id.field_endpoint)
+                                if (endpointEditText.text.isEmpty() ||
+                                    endpointEditText.text.toString() == getString(R.string.settings_option_openai_api_default_endpoint) ||
+                                    endpointEditText.text.toString() == getString(R.string.settings_option_whisper_asr_webservice_default_endpoint) ||
+                                    endpointEditText.text.toString() == getString(R.string.settings_option_nvidia_nim_default_endpoint)
+                                ) {
+                                    endpointEditText.setText(getString(R.string.settings_option_voxtral_default_endpoint))
+                                }
+                                val modelEditText: EditText = findViewById<EditText>(R.id.field_model)
+                                modelEditText.setText(getString(R.string.settings_option_voxtral_default_model))
+                                val languageCodeEditText: EditText = findViewById<EditText>(R.id.field_language_code)
+                                languageCodeEditText.setText(getString(R.string.settings_option_voxtral_default_language))
+                            } else if (selectedItem == getString(R.string.settings_option_elevenlabs)) {
+                                val endpointEditText: EditText = findViewById<EditText>(R.id.field_endpoint)
+                                if (endpointEditText.text.isEmpty() ||
+                                    endpointEditText.text.toString() == getString(R.string.settings_option_openai_api_default_endpoint) ||
+                                    endpointEditText.text.toString() == getString(R.string.settings_option_whisper_asr_webservice_default_endpoint) ||
+                                    endpointEditText.text.toString() == getString(R.string.settings_option_nvidia_nim_default_endpoint)
+                                ) {
+                                    endpointEditText.setText(getString(R.string.settings_option_elevenlabs_default_endpoint))
+                                }
+                                val modelEditText: EditText = findViewById<EditText>(R.id.field_model)
+                                modelEditText.setText(getString(R.string.settings_option_elevenlabs_default_model))
+                                val languageCodeEditText: EditText = findViewById<EditText>(R.id.field_language_code)
+                                languageCodeEditText.setText(getString(R.string.settings_option_elevenlabs_default_language))
                             }
                         }
                     }
@@ -321,7 +347,9 @@ class MainActivity : AppCompatActivity() {
                 SettingStringDropdown(R.id.spinner_speech_to_text_backend, SPEECH_TO_TEXT_BACKEND, listOf(
                     getString(R.string.settings_option_openai_api),
                     getString(R.string.settings_option_whisper_asr_webservice),
-                    getString(R.string.settings_option_nvidia_nim)
+                    getString(R.string.settings_option_nvidia_nim),
+                    getString(R.string.settings_option_voxtral),
+                    getString(R.string.settings_option_elevenlabs)
                 ), getString(R.string.settings_option_openai_api)),
                 SettingText(R.id.field_endpoint, ENDPOINT, getString(R.string.settings_option_openai_api_default_endpoint)),
                 SettingText(R.id.field_language_code, LANGUAGE_CODE, getString(R.string.settings_option_openai_api_default_language)),

--- a/android/app/src/main/java/com/example/whispertoinput/WhisperTranscriber.kt
+++ b/android/app/src/main/java/com/example/whispertoinput/WhisperTranscriber.kt
@@ -32,6 +32,8 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
+import org.json.JSONException
+import org.json.JSONObject
 import java.io.File
 import com.github.liuyueyi.quick.transfer.ChineseUtils
 
@@ -96,6 +98,26 @@ class WhisperTranscriber {
             }
 
             var rawText = response.body!!.string().trim()
+            
+            // Handle Voxtral response: {"text": "transcription"}
+            if (speechToTextBackend == context.getString(R.string.settings_option_voxtral)) {
+                try {
+                    val json = JSONObject(rawText)
+                    rawText = json.optString("text", "").trim()
+                } catch (e: JSONException) {
+                    // If not JSON, use as-is
+                }
+            }
+            
+            // Handle ElevenLabs response: {"text": "transcription", "language_code": "en", ...}
+            if (speechToTextBackend == context.getString(R.string.settings_option_elevenlabs)) {
+                try {
+                    val json = JSONObject(rawText)
+                    rawText = json.optString("text", "").trim()
+                } catch (e: JSONException) {
+                    // If not JSON, use as-is
+                }
+            }
             
             // For NVIDIA NIM, remove quotes if they wrap the text
             // Not sure if this is a bug or a feature...
@@ -172,72 +194,76 @@ class WhisperTranscriber {
         apiKey: String,
         model: String
     ): Request {
-        // Please refer to the following for the endpoint/payload definitions:
-        // OpenAI API:
-        // - https://platform.openai.com/docs/api-reference/audio/createTranscription
-        // - https://platform.openai.com/docs/api-reference/making-requests
-        // Whisper ASR WebService:
-        // - https://ahmetoner.com/whisper-asr-webservice/run/#usage
-        // NVIDIA NIM:
-        // - No public documentation for HTTP-style requests.
-        // - Source code at `/opt/nim/inference.py` in docker container `nvcr.io/nim/nvidia/riva-asr:1.3.0`.
-        /*
-            ...
-            @HttpNIMApiInterface.route('/v1/audio/transcriptions', methods=["post"])
-            async def transcriptions(
-                self,
-                file: UploadFile = File(...),
-                model: Optional[str] = Form(None),
-                language: Optional[str] = Form(None),
-                prompt: Optional[str] = Form(None),
-                response_format: Optional[str] = Form(None),
-                temperature: Optional[float] = Form(None),
-            ):
-            ...
-         */
         val file: File = File(filename)
         val fileBody: RequestBody = file.asRequestBody(mediaType.toMediaTypeOrNull())
         val requestBody: RequestBody = MultipartBody.Builder().apply {
             setType(MultipartBody.FORM)
-            // Determine filename based on media type
             val formDataFilename = if (mediaType == "audio/ogg") "@audio.ogg" else "@audio.m4a"
-            
-            // Add file to payload
-            if (speechToTextBackend == context.getString(R.string.settings_option_openai_api) || 
-                speechToTextBackend == context.getString(R.string.settings_option_nvidia_nim)) {
-                addFormDataPart("file", formDataFilename, fileBody)
-            } else if (speechToTextBackend == context.getString(R.string.settings_option_whisper_asr_webservice)) {
-                addFormDataPart("audio_file", formDataFilename, fileBody)
-            }
-            // Add backend-specific parameters to payload
-            if (speechToTextBackend == context.getString(R.string.settings_option_openai_api)) {
-                addFormDataPart("model", model)
-                addFormDataPart("response_format", "text")
-            }
-            if (speechToTextBackend == context.getString(R.string.settings_option_nvidia_nim)) {
-                addFormDataPart("language", languageCode)
-                addFormDataPart("response_format", "text")
-            }
-        }.build()
 
-        val requestHeaders: Headers = Headers.Builder().apply {
-            if (speechToTextBackend == context.getString(R.string.settings_option_openai_api)) {
-                // Foolproof message
-                if (apiKey == "") {
-                    throw Exception(context.getString(R.string.error_apikey_unset))
+            // File field
+            when (speechToTextBackend) {
+                context.getString(R.string.settings_option_openai_api),
+                context.getString(R.string.settings_option_nvidia_nim),
+                context.getString(R.string.settings_option_voxtral),
+                context.getString(R.string.settings_option_elevenlabs) -> {
+                    addFormDataPart("file", formDataFilename, fileBody)
                 }
-                add("Authorization", "Bearer $apiKey")
+                context.getString(R.string.settings_option_whisper_asr_webservice) -> {
+                    addFormDataPart("audio_file", formDataFilename, fileBody)
+                }
             }
-            add("Content-Type", "multipart/form-data")
+
+            // Provider-specific parameters
+            when (speechToTextBackend) {
+                context.getString(R.string.settings_option_openai_api) -> {
+                    addFormDataPart("model", model)
+                    addFormDataPart("response_format", "text")
+                }
+                context.getString(R.string.settings_option_nvidia_nim) -> {
+                    addFormDataPart("language", languageCode)
+                    addFormDataPart("response_format", "text")
+                }
+                context.getString(R.string.settings_option_voxtral) -> {
+                    addFormDataPart("model", model)
+                    if (languageCode != "auto" && languageCode.isNotEmpty()) {
+                        addFormDataPart("language", languageCode)
+                    }
+                }
+                context.getString(R.string.settings_option_elevenlabs) -> {
+                    addFormDataPart("model_id", model)
+                    if (languageCode != "auto" && languageCode.isNotEmpty()) {
+                        addFormDataPart("language_code", languageCode)
+                    }
+                }
+            }
         }.build()
 
-        // Build URL with endpoint-specific parameters
+        // Headers - NO manual Content-Type (OkHttp adds boundary)
+        val requestHeaders: Headers = Headers.Builder().apply {
+            when (speechToTextBackend) {
+                context.getString(R.string.settings_option_openai_api),
+                context.getString(R.string.settings_option_voxtral) -> {
+                    if (apiKey == "") {
+                        throw Exception(context.getString(R.string.error_apikey_unset))
+                    }
+                    add("Authorization", "Bearer $apiKey")
+                }
+                context.getString(R.string.settings_option_elevenlabs) -> {
+                    if (apiKey == "") {
+                        throw Exception(context.getString(R.string.error_apikey_unset))
+                    }
+                    add("xi-api-key", apiKey)
+                }
+            }
+        }.build()
+
+        // URL building - FIXED: separate OpenAI from Whisper ASR Webservice
         val url = when (speechToTextBackend) {
-            context.getString(R.string.settings_option_openai_api),
             context.getString(R.string.settings_option_whisper_asr_webservice) -> {
+                // Whisper ASR Webservice uses query params
                 "$endpoint?encode=true&task=transcribe&language=$languageCode&word_timestamps=false&output=txt"
             }
-            else -> endpoint
+            else -> endpoint  // OpenAI, NVIDIA NIM, Voxtral, ElevenLabs use direct endpoint
         }
 
         return Request.Builder()

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="whisper_to_input_settings_title">Whisper To Input Settings</string>
     <string name="settings_btn_apply">Apply</string>
     <string name="settings_speech_to_text_backend">Speech to Text Backend</string>
-    <string name="settings_speech_to_text_backend_desc">Use the official OpenAI API, Whisper ASR Webservice, or NVIDIA NIM backend.</string>
+    <string name="settings_speech_to_text_backend_desc">Use the official OpenAI API, Whisper ASR Webservice, NVIDIA NIM, Voxtral (Mistral), or ElevenLabs Scribe backend.</string>
     <string name="settings_option_openai_api">OpenAI API</string>
     <string name="settings_option_openai_api_default_endpoint">https://api.openai.com/v1/audio/transcriptions</string>
     <string name="settings_option_openai_api_default_model">whisper-1</string>
@@ -40,10 +40,22 @@
     <string name="settings_option_nvidia_nim_default_endpoint">http://localhost:9000/v1/audio/transcriptions</string>
     <string name="settings_option_nvidia_nim_default_model"></string> <!-- Empty default model -->
     <string name="settings_option_nvidia_nim_default_language">multi</string> <!-- Empty default language -->
+    <string name="settings_option_voxtral">Voxtral (Mistral)</string>
+    <string name="settings_option_voxtral_default_endpoint">https://api.mistral.ai/v1/audio/transcriptions</string>
+    <string name="settings_option_voxtral_default_model">voxtral-mini-latest</string>
+    <string name="settings_option_voxtral_default_language">auto</string>
+
+    <!-- ElevenLabs Scribe -->
+    <string name="settings_option_elevenlabs">ElevenLabs Scribe</string>
+    <string name="settings_option_elevenlabs_default_endpoint">https://api.elevenlabs.io/v1/speech-to-text</string>
+    <string name="settings_option_elevenlabs_default_model">scribe_v1</string>
+    <string name="settings_option_elevenlabs_default_language">auto</string>
     <string-array name="settings_speech_to_text_backend_array">
         <item>@string/settings_option_openai_api</item>
         <item>@string/settings_option_whisper_asr_webservice</item>
         <item>@string/settings_option_nvidia_nim</item>
+        <item>@string/settings_option_voxtral</item>
+        <item>@string/settings_option_elevenlabs</item>
     </string-array>
     <string name="settings_endpoint">Endpoint</string>
     <string name="settings_endpoint_desc">The host and port for the OpenAI API, Whisper ASR Webservice, or NVIDIA NIM endpoint.</string>


### PR DESCRIPTION
## Changes

- **Voxtral (Mistral AI)**: New speech-to-text backend with auto language detection and default model 
- **ElevenLabs Scribe**: New speech-to-text backend using  model with custom  authentication
- **GitHub Actions**: Added CI workflow to build debug APKs on push
- Removed unused  permission
- Updated README with configuration instructions for new backends

## Testing

1. Install the debug APK from the [Actions artifact](https://github.com/happytomatoe/whisper-to-input/actions) or build locally
2. In settings, select either **Voxtral (Mistral)** or **ElevenLabs Scribe** from the dropdown
3. Enter your API key and test transcription

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Voxtral (Mistral) and ElevenLabs Scribe as speech-to-text backend options.
  * Added automatic default endpoint, model, and language settings for both providers.
  * Added support for processing transcription responses from the new providers.
  * Added automated Android debug APK builds available as downloadable artifacts.

* **Documentation**
  * Added setup examples and provider configuration details for Voxtral and ElevenLabs Scribe.

* **Bug Fixes**
  * Improved request handling for different speech-to-text service formats.
  * Removed unnecessary storage permission from the Android app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->